### PR TITLE
External Grammar Files

### DIFF
--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/Errors.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/Errors.kt
@@ -21,3 +21,8 @@ class InvalidExpression(
     symbol: String,
     cause: Throwable? = null
 ): IllegalArgumentException("Illegal expression '$symbol'", cause)
+
+class GrammarParseException(
+    message: String,
+    cause: Throwable? = null
+): Exception(message, cause)

--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/FilterRegistry.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/FilterRegistry.kt
@@ -3,10 +3,10 @@ package com.github.thedeathlycow.calyx.kt
 
 internal class FilterRegistry {
 
-    private val filterHolders: MutableMap<String, (String, Options) -> String> = mutableMapOf()
+    private val filters: MutableMap<String, (String, Options) -> String> = mutableMapOf()
 
     operator fun get(name: String): (String, Options) -> String {
-        val filter = filterHolders[name] ?: throw UndefinedFilter(name)
+        val filter = filters[name] ?: throw UndefinedFilter(name)
         return { input, options ->
             try {
                 filter(input, options)
@@ -21,7 +21,7 @@ internal class FilterRegistry {
             val annotation: FilterName? = method.getAnnotation(FilterName::class.java)
             if (annotation != null) {
                 val name = annotation.name
-                filterHolders[name] = { input, options ->
+                filters[name] = { input, options ->
                     method(instance, input, options) as String
                 }
             }

--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/FilterRegistry.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/FilterRegistry.kt
@@ -5,24 +5,17 @@ internal class FilterRegistry {
 
     private val filters: MutableMap<String, (String, Options) -> String> = mutableMapOf()
 
-    operator fun get(name: String): (String, Options) -> String {
-        val filter = filters[name] ?: throw UndefinedFilter(name)
-        return { input, options ->
-            try {
-                filter(input, options)
-            } catch (e: IllegalArgumentException) {
-                throw IncorrectFilterSignature(name, e)
-            }
-        }
-    }
+    operator fun get(name: String): (String, Options) -> String = filters[name] ?: throw UndefinedFilter(name)
 
     fun addFilters(instance: Any) {
         for (method in instance.javaClass.methods) {
-            val annotation: FilterName? = method.getAnnotation(FilterName::class.java)
-            if (annotation != null) {
-                val name = annotation.name
-                filters[name] = { input, options ->
+            val annotation: FilterName = method.getAnnotation(FilterName::class.java) ?: continue
+            val name = annotation.name
+            filters[name] = { input, options ->
+                try {
                     method(instance, input, options) as String
+                } catch (e: IllegalArgumentException) {
+                    throw IncorrectFilterSignature(name, e)
                 }
             }
         }

--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/Grammar.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/Grammar.kt
@@ -1,5 +1,9 @@
 package com.github.thedeathlycow.calyx.kt
 
+import com.github.thedeathlycow.calyx.kt.serialize.GrammarJsonParser
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.FileReader
 import java.math.BigDecimal
 import kotlin.random.Random
 import kotlin.reflect.KClass
@@ -37,8 +41,55 @@ class Grammar(
         registrationCallback.invoke(this)
     }
 
-    fun load(fileName: String) {
+    companion object {
 
+        private val gson: Gson = GsonBuilder()
+            .registerTypeAdapter(Grammar::class.java, GrammarJsonParser)
+            .create()
+
+        /**
+         * Loads a grammar from a file, given by [fileName]. Currently only supports JSON parsing.
+         *
+         * @param fileName The name of the file to parse from.
+         * @return Returns the Grammar described in the file.
+         * @throws GrammarParseException Thrown if there is an issue parsing the grammar. The cause will contain more details.
+         */
+        @Throws(GrammarParseException::class)
+        fun load(fileName: String): Grammar {
+            try {
+                return readGrammarFile(fileName)
+            } catch (exception: Exception) {
+                throw GrammarParseException("Error parsing grammar", exception)
+            }
+        }
+
+        /**
+         * Directly parses a grammar JSON string into a [Grammar]
+         *
+         * @param rawJson A raw JSON string to parse into a grammar
+         * @return Returns the grammar representing by the JSON string
+         * @throws GrammarParseException Thrown if there is an issue parsing the grammar. The cause will contain more details.
+         */
+        @Throws(GrammarParseException::class)
+        fun loadJson(rawJson: String): Grammar {
+            try {
+                return gson.fromJson(rawJson, Grammar::class.java)
+            } catch (exception: Exception) {
+                throw GrammarParseException("Error parsing grammar", exception)
+            }
+        }
+
+        private fun readGrammarFile(fileName: String): Grammar {
+            FileReader(fileName).use {
+                if (fileName.endsWith(".json")) {
+                    return gson.fromJson(it, Grammar::class.java)
+                } else if (fileName.endsWith(".yaml")) {
+                    TODO("YAML support is not yet implemented, sorry!")
+                } else {
+                    throw IllegalArgumentException("Grammars must be specified in a JSON file!")
+                }
+            }
+        }
     }
 
     fun start(productions: List<String>): Grammar {

--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/serialize/GrammarJsonParser.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/serialize/GrammarJsonParser.kt
@@ -1,0 +1,63 @@
+package com.github.thedeathlycow.calyx.kt.serialize
+
+import com.github.thedeathlycow.calyx.kt.Grammar
+import com.github.thedeathlycow.calyx.kt.GrammarParseException
+import com.google.gson.*
+import java.lang.reflect.Type
+
+object GrammarJsonParser : JsonDeserializer<Grammar> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): Grammar {
+        val jsonObject: JsonObject = json.asJsonObject;
+
+        val grammar = Grammar()
+
+        // explicitly require a start rule!
+        this.parseRule(
+            grammar,
+            "start",
+            jsonObject["start"] ?: throw IllegalArgumentException("A 'start' rule is required for grammars")
+        )
+
+        jsonObject.keySet().forEach {
+            // start already parsed -- don't do it again
+            if (it != "start") {
+                this.parseRule(grammar, it, jsonObject[it])
+            }
+        }
+
+        return grammar
+    }
+
+    private fun parseRule(grammar: Grammar, ruleName: String, json: JsonElement) {
+        when {
+            json.isJsonPrimitive -> {
+                grammar.rule(ruleName, json.asString)
+            }
+
+            json.isJsonArray -> {
+                val prods = mutableListOf<String>()
+                json.asJsonArray.forEach {
+                    prods.add(it.asString)
+                }
+                grammar.rule(ruleName, prods)
+            }
+
+            json.isJsonObject -> {
+                val jsonObject = json.asJsonObject
+                val prods = mutableMapOf<String, Double>()
+                jsonObject.keySet().forEach {
+                    prods[it] = jsonObject[it].asDouble
+                }
+                grammar.rule(ruleName, prods)
+            }
+
+            else -> {
+                throw JsonParseException("Rule '$ruleName' is not a primitive, array, or object compound")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/thedeathlycow/calyx/kt/serialize/GrammarJsonParser.kt
+++ b/src/main/kotlin/com/github/thedeathlycow/calyx/kt/serialize/GrammarJsonParser.kt
@@ -15,18 +15,8 @@ object GrammarJsonParser : JsonDeserializer<Grammar> {
 
         val grammar = Grammar()
 
-        // explicitly require a start rule!
-        this.parseRule(
-            grammar,
-            "start",
-            jsonObject["start"] ?: throw IllegalArgumentException("A 'start' rule is required for grammars")
-        )
-
         jsonObject.keySet().forEach {
-            // start already parsed -- don't do it again
-            if (it != "start") {
-                this.parseRule(grammar, it, jsonObject[it])
-            }
+            this.parseRule(grammar, it, jsonObject[it])
         }
 
         return grammar

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/CycleTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/CycleTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Cycle
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/CycleTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/CycleTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Cycle
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ExpansionTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ExpansionTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ExpansionTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ExpansionTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/FilterTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/FilterTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/FilterTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/FilterTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
@@ -1,0 +1,134 @@
+package com.github.thedeathlycow.calyx.kt
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+
+class GrammarJsonTest {
+
+    @Test
+    fun parseStartRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": "Hello world!"
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello world!", grammar.generate().text)
+    }
+
+    @Test
+    fun parseNoStartRuleThrows() {
+        assertThrows<GrammarParseException> {
+            Grammar.loadJson(
+                """
+                    {
+                        "not_start": "Hello world!"
+                    }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun parseSimpleRecursiveRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": "Hello {world}!",
+                    "world": "earth"
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello earth!", grammar.generate().text)
+    }
+
+    @Test
+    fun parseUniformRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": ["Hello world!"]
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello world!", grammar.generate().text)
+    }
+
+    @Test
+    fun parseRecursiveUniformRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": ["Hello {world}!"],
+                    "world": "earth"
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello earth!", grammar.generate().text)
+    }
+
+    @Test
+    fun parseWeightedRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": {
+                        "Hello world!": 1
+                    }
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello world!", grammar.generate().text)
+    }
+
+    @Test
+    fun parseRecursiveWeightedRule() {
+        val grammar: Grammar = Grammar.loadJson(
+            """
+                {
+                    "start": {
+                        "Hello {world}!": 1
+                    },
+                    "world": "earth"
+                }
+                """.trimIndent()
+        )
+
+        assertEquals("Hello earth!", grammar.generate().text)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "NaN",
+            "true",
+            "[]",
+            """{"hello": "lol"}"""
+        ]
+    )
+    fun parseRecursiveWeightedRule_failsOnNonNumber(invalid: String) {
+        assertThrows<GrammarParseException> {
+            Grammar.loadJson(
+                """
+                {
+                    "start": {
+                        "Hello {world}!": $invalid
+                    },
+                    "world": "earth"
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+
+}

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
@@ -109,6 +109,7 @@ class GrammarJsonTest {
     @ParameterizedTest
     @ValueSource(
         strings = [
+            "null",
             "NaN",
             "true",
             "[]",
@@ -124,6 +125,39 @@ class GrammarJsonTest {
                         "Hello {world}!": $invalid
                     },
                     "world": "earth"
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "null",
+            "[]",
+            """{"hello": "lol"}"""
+        ]
+    )
+    fun parseRecursiveWeightedRule_failsOnNonPrimitiveList(invalid: String) {
+        assertThrows<GrammarParseException> {
+            Grammar.loadJson(
+                """
+                {
+                    "start": [$invalid]
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun parseRule_failsWhenNull() {
+        assertThrows<GrammarParseException> {
+            Grammar.loadJson(
+                """
+                {
+                    "start": null
                 }
                 """.trimIndent()
             )

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarJsonTest.kt
@@ -1,6 +1,7 @@
 package com.github.thedeathlycow.calyx.kt
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -22,8 +23,8 @@ class GrammarJsonTest {
     }
 
     @Test
-    fun parseNoStartRuleThrows() {
-        assertThrows<GrammarParseException> {
+    fun startRuleNotRequired() {
+        assertDoesNotThrow {
             Grammar.loadJson(
                 """
                     {

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.FilterName
 import com.github.thedeathlycow.calyx.kt.Grammar

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/GrammarTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.FilterName
 import com.github.thedeathlycow.calyx.kt.Grammar

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/RegistryTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/RegistryTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/RegistryTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/RegistryTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ResultTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ResultTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test
+package com.github.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Result

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ResultTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/ResultTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt
+package com.github.thedeathlycow.calyx.kt
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Result

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/LooseModeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/LooseModeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.grammar
+package com.github.calyx.kt.grammar
 
 import com.github.thedeathlycow.calyx.kt.Grammar
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/LooseModeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/LooseModeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.grammar
+package com.github.thedeathlycow.calyx.kt.grammar
 
 import com.github.thedeathlycow.calyx.kt.Grammar
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/WeightedBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/WeightedBranchTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.grammar
+package com.github.calyx.kt.grammar
 
 import com.github.thedeathlycow.calyx.kt.Grammar
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/WeightedBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/grammar/WeightedBranchTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.grammar
+package com.github.thedeathlycow.calyx.kt.grammar
 
 import com.github.thedeathlycow.calyx.kt.Grammar
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/UniformBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/UniformBranchTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.production
+package com.github.calyx.kt.production
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/UniformBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/UniformBranchTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.production
+package com.github.thedeathlycow.calyx.kt.production
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/WeightedBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/WeightedBranchTest.kt
@@ -1,6 +1,6 @@
-package com.github.calyx.kt.production
+package com.github.thedeathlycow.calyx.kt.production
 
-import com.github.calyx.kt.util.assertNumberWithinPercentRange
+import com.github.thedeathlycow.calyx.kt.util.assertNumberWithinPercentRange
 import com.github.thedeathlycow.calyx.kt.Options
 import com.github.thedeathlycow.calyx.kt.Registry
 import com.github.thedeathlycow.calyx.kt.production.WeightedBranch

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/WeightedBranchTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/production/WeightedBranchTest.kt
@@ -1,6 +1,6 @@
-package com.github.calyx.kt.test.production
+package com.github.calyx.kt.production
 
-import com.github.calyx.kt.test.util.assertNumberWithinPercentRange
+import com.github.calyx.kt.util.assertNumberWithinPercentRange
 import com.github.thedeathlycow.calyx.kt.Options
 import com.github.thedeathlycow.calyx.kt.Registry
 import com.github.thedeathlycow.calyx.kt.production.WeightedBranch

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/AtomNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/AtomNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/AtomNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/AtomNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionChainTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionChainTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Registry

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionChainTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionChainTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Registry

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/ExpressionNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/MemoNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/MemoNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/MemoNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/MemoNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeFragmentationTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeFragmentationTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.InvalidExpression
 import com.github.thedeathlycow.calyx.kt.syntax.TemplateNode

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeFragmentationTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeFragmentationTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.InvalidExpression
 import com.github.thedeathlycow.calyx.kt.syntax.TemplateNode

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/TemplateNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Expansion
 import com.github.thedeathlycow.calyx.kt.Options

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/UniqNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/UniqNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.syntax
+package com.github.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Options
 import com.github.thedeathlycow.calyx.kt.Registry

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/UniqNodeTest.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/syntax/UniqNodeTest.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.syntax
+package com.github.thedeathlycow.calyx.kt.syntax
 
 import com.github.thedeathlycow.calyx.kt.Options
 import com.github.thedeathlycow.calyx.kt.Registry

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/util/ExtraAssertions.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/util/ExtraAssertions.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.test.util
+package com.github.calyx.kt.util
 
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/com/github/thedeathlycow/calyx/kt/util/ExtraAssertions.kt
+++ b/src/test/kotlin/com/github/thedeathlycow/calyx/kt/util/ExtraAssertions.kt
@@ -1,4 +1,4 @@
-package com.github.calyx.kt.util
+package com.github.thedeathlycow.calyx.kt.util
 
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
Add ability to supply grammars as JSON files and strings, according the [spec from Ruby](https://github.com/maetl/calyx/tree/main#external-file-formats)

Possibly also include YAML support in this PR? 